### PR TITLE
feat: create template config for semantic release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# tmpl-semantic-release
+# Template: Semantic Release
+
+A template that performs a semantic-release for NPM-based modules, using the [semantic-release](https://www.npmjs.com/package/semantic-release) NPM module.
+
+## Usage
+
+### Secrets
+
+The following secrets are needed in order to execute correctly:
+
+* `NPM_TOKEN` - NPM token. Used for publishing the updated version to the NPM Registry.
+* `GH_TOKEN` - Github token. Used for tagging the correct commit SHA with the respective version.
+
+#### Example
+
+```
+# screwdriver.yaml
+---
+jobs:
+  main:
+    secrets:
+    # These secrets are defined in the Pipeline page
+    - NPM_TOKEN
+    - GH_TOKEN
+    template: screwdriver-cd/semantic-release@stable
+```
+
+### What the Template Does
+
+This template executes the following steps:
+
+* `check_prerequisite`
+* `install_binaries`
+* `publish`
+
+#### check_prerequisite
+
+This step ensures that the `NPM_TOKEN` and `GH_TOKEN` secret variables are all set. However, this step does *not* verify nor validate the values; it only checks that they are populated.
+
+#### install_binaries
+
+This step installs the necessary binaries and libraries in order to perform all the template operations.
+
+Overriding this step may cause unwanted side effects during the publish.
+
+#### publish
+
+This step is what performs the semantic release operations via the [semantic-release](https://www.npmjs.com/package/semantic-release) NPM module.

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,0 +1,20 @@
+workflow:
+- publish
+
+shared:
+  image: node:6
+
+jobs:
+  main:
+    environment:
+      SD_TEMPLATE_PATH: semantic_release_template.yaml
+    steps:
+    - install_binaries: npm i -g screwdriver-template-main
+    - verify_template: template-validate
+  publish:
+    steps:
+    - install_binaries: npm i -g screwdriver-template-main
+    - publish_template: template-publish | tee $SD_ARTIFACTS_DIR/publish.output
+    - save_version: cat $SD_ARTIFACTS_DIR/publish.output | awk -F[@\ ] '{print $3}' | tee $SD_ARTIFACTS_DIR/template_version
+    - tag_latest: template-tag --name screwdriver-cd/semantic-release --version `cat $SD_ARTIFACTS_DIR/template_version` --tag latest
+    - tag_stable: template-tag --name screwdriver-cd/semantic-release --version `cat $SD_ARTIFACTS_DIR/template_version` --tag stable

--- a/semantic_release_template.yaml
+++ b/semantic_release_template.yaml
@@ -1,0 +1,12 @@
+name: screwdriver-cd/semantic-release
+version: '1.0'
+description: Template for semantic release
+maintainer: idk
+config:
+  image: node:6
+  steps:
+    - check_prerequisite: |
+        if [ -z "$NPM_TOKEN" ]; then echo "NPM Token not set to NPM_TOKEN. Exiting..." && exit 1; fi
+        if [ -z "$GH_TOKEN" ]; then echo "Github Token not set to GH_TOKEN. Exiting..." && exit 1; fi
+    - install_binaries: npm i --no-save semantic-release@^7
+    - publish: semantic-release pre && npm publish && semantic-release post


### PR DESCRIPTION
## Context

The latest release of [semantic-release](https://www.npmjs.com/package/semantic-release) requires the use of `node:8`. With the official LTS of Node 8 set for some time in October, we do not want to pin every pipeline that requires `semantic-release` and have to undo the efforts later down the line.

By creating a template, we can abstract the semantic release process and concentrate the maintenance effort to a single template instead of over all repositories.

## Objective

Abstract the semantic release operations in a dedicated template.