### PR TITLE
fix: Add semantic release template for node:8

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,20 +1,35 @@
-workflow:
-- publish
-
 shared:
   image: node:6
-  environment:
-    SD_TEMPLATE_PATH: semantic_release_template.yaml
 
 jobs:
   main:
+    requires: [~pr, ~commit]
     steps:
     - install_binaries: npm i -g screwdriver-template-main
-    - verify_template: template-validate
-  publish:
+    - verify_node6: |
+        export SD_TEMPLATE_PATH=semantic_release_template.yaml
+        template-validate
+    - verify_node8: |
+        export SD_TEMPLATE_PATH=semantic_release_template_node8.yaml
+        template-validate
+  publish-node6:
+    requires: [main]
+    environment:
+      SD_TEMPLATE_PATH: semantic_release_template.yaml
     steps:
     - install_binaries: npm i -g screwdriver-template-main
     - publish_template: template-publish | tee $SD_ARTIFACTS_DIR/publish.output
     - save_version: cat $SD_ARTIFACTS_DIR/publish.output | awk -F[@\ ] '{print $3}' | tee $SD_ARTIFACTS_DIR/template_version
     - tag_latest: template-tag --name screwdriver-cd/semantic-release --version `cat $SD_ARTIFACTS_DIR/template_version` --tag latest
     - tag_stable: template-tag --name screwdriver-cd/semantic-release --version `cat $SD_ARTIFACTS_DIR/template_version` --tag stable
+  publish-node8:
+    requires: [main]
+    image: node:8
+    environment:
+      SD_TEMPLATE_PATH: semantic_release_template_node8.yaml
+    steps:
+    - install_binaries: npm i -g screwdriver-template-main
+    - publish_template: template-publish | tee $SD_ARTIFACTS_DIR/publish_node8.output
+    - save_version: cat $SD_ARTIFACTS_DIR/publish_node8.output | awk -F[@\ ] '{print $3}' | tee $SD_ARTIFACTS_DIR/template_version_node8
+    - tag_latest: template-tag --name screwdriver-cd/semantic-release-node8 --version `cat $SD_ARTIFACTS_DIR/template_version_node8` --tag latest
+    - tag_stable: template-tag --name screwdriver-cd/semantic-release-node8 --version `cat $SD_ARTIFACTS_DIR/template_version_node8` --tag stable

--- a/semantic_release_template_node8.yaml
+++ b/semantic_release_template_node8.yaml
@@ -1,0 +1,12 @@
+name: screwdriver-cd/semantic-release-node8
+version: '1.0'
+description: Template for semantic release using node8 image
+maintainer: tiffanykyi@gmail.com
+config:
+  image: node:8
+  steps:
+    - check_prerequisite: |
+        if [ -z "$NPM_TOKEN" ]; then echo "NPM Token not set to NPM_TOKEN. Exiting..." && exit 1; fi
+        if [ -z "$GH_TOKEN" ]; then echo "Github Token not set to GH_TOKEN. Exiting..." && exit 1; fi
+    - install_binaries: npm i --no-save semantic-release
+    - publish: ./node_modules/.bin/semantic-release pre && npm publish && ./node_modules/.bin/semantic-release post

--- a/semantic_release_template_node8.yaml
+++ b/semantic_release_template_node8.yaml
@@ -8,5 +8,5 @@ config:
     - check_prerequisite: |
         if [ -z "$NPM_TOKEN" ]; then echo "NPM Token not set to NPM_TOKEN. Exiting..." && exit 1; fi
         if [ -z "$GH_TOKEN" ]; then echo "Github Token not set to GH_TOKEN. Exiting..." && exit 1; fi
-    - install_binaries: npm i --no-save semantic-release
-    - publish: ./node_modules/.bin/semantic-release pre && npm publish && ./node_modules/.bin/semantic-release post
+    - install_binaries: npm i --no-save semantic-release@^15
+    - publish: ./node_modules/.bin/semantic-release


### PR DESCRIPTION
## Context
We need to create a semantic release template for node:8.
Since we don't want to update all our repos that are using node:6 yet, we're creating a separate template for now.

## Objective
This PR adds a semantic release template that uses node:8 image and uses semantic-release package at version 15.

## Related links
- semantic-release docs: https://github.com/semantic-release/semantic-release/compare/v8.2.3...v9.0.0#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L128
