### PR TITLE
feat: upgrade to semantic-release:v18.0.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2017, Screwdriver
+Copyright (c) 2017, Yahoo Inc
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,18 +1,18 @@
 shared:
-  image: node:6
+  image: node:12
 
 jobs:
   main:
     requires: [~pr, ~commit]
     steps:
     - install_binaries: npm i -g screwdriver-template-main
-    - verify_node6: |
+    - verify_node12: |
         export SD_TEMPLATE_PATH=semantic_release_template.yaml
         template-validate
     - verify_node8: |
         export SD_TEMPLATE_PATH=semantic_release_template_node8.yaml
         template-validate
-  publish-node6:
+  publish-node12:
     requires: [main]
     environment:
       SD_TEMPLATE_PATH: semantic_release_template.yaml

--- a/semantic_release_template.yaml
+++ b/semantic_release_template.yaml
@@ -1,6 +1,6 @@
 name: screwdriver-cd/semantic-release
 version: '1.0'
-description: Template for semantic release
+description: Template for semantic release with Node 10 or higher
 maintainer: daolam112@gmail.com
 config:
   image: node:6

--- a/semantic_release_template.yaml
+++ b/semantic_release_template.yaml
@@ -8,5 +8,5 @@ config:
     - check_prerequisite: |
         if [ -z "$NPM_TOKEN" ]; then echo "NPM Token not set to NPM_TOKEN. Exiting..." && exit 1; fi
         if [ -z "$GH_TOKEN" ]; then echo "Github Token not set to GH_TOKEN. Exiting..." && exit 1; fi
-    - install_binaries: npm i --no-save semantic-release@^7
+    - install_binaries: npm i --no-save semantic-release@^18
     - publish: ./node_modules/.bin/semantic-release pre && npm publish && ./node_modules/.bin/semantic-release post

--- a/semantic_release_template.yaml
+++ b/semantic_release_template.yaml
@@ -1,9 +1,9 @@
 name: screwdriver-cd/semantic-release
-version: '1.0'
+version: '2.0'
 description: Template for semantic release with Node 10 or higher
-maintainer: daolam112@gmail.com
+maintainer: screwdriver-oss@yahooinc.com
 config:
-  image: node:6
+  image: node:12
   steps:
     - check_prerequisite: |
         if [ -z "$NPM_TOKEN" ]; then echo "NPM Token not set to NPM_TOKEN. Exiting..." && exit 1; fi

--- a/semantic_release_template_node8.yaml
+++ b/semantic_release_template_node8.yaml
@@ -1,7 +1,7 @@
 name: screwdriver-cd/semantic-release-node8
 version: '1.0'
 description: Template for semantic release using node8 image
-maintainer: tiffanykyi@gmail.com
+maintainer: screwdriver-oss@yahooinc.com
 config:
   image: node:8
   steps:


### PR DESCRIPTION
## Context

All Screwdriver packages work with node:12 and semantic release needs to be upgraded to a latest version

## Objective

upgrade to semantic-release:v18.0.0

## References

https://github.com/semantic-release/semantic-release/releases/tag/v18.0.0

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
