### PR TITLE
Allow use of GITHUB_TOKEN and GH_TOKEN

### DIFF
--- a/semantic_release_template.yaml
+++ b/semantic_release_template.yaml
@@ -7,6 +7,6 @@ config:
   steps:
     - check_prerequisite: |
         if [ -z "$NPM_TOKEN" ]; then echo "NPM Token not set to NPM_TOKEN. Exiting..." && exit 1; fi
-        if [ -z "$GH_TOKEN" ]; then echo "Github Token not set to GH_TOKEN. Exiting..." && exit 1; fi
+        if [[ -z "$GITHUB_TOKEN" && -z "$GH_TOKEN" ]]; then echo "Github Token not set to either GITHUB_TOKEN or GH_TOKEN. Exiting..." && exit 1; fi
     - install_binaries: npm i --no-save semantic-release@^22
     - publish: ./node_modules/.bin/semantic-release

--- a/semantic_release_template.yaml
+++ b/semantic_release_template.yaml
@@ -7,6 +7,6 @@ config:
   steps:
     - check_prerequisite: |
         if [ -z "$NPM_TOKEN" ]; then echo "NPM Token not set to NPM_TOKEN. Exiting..." && exit 1; fi
-        if [[ -z "$GITHUB_TOKEN" && -z "$GH_TOKEN" ]]; then echo "Github Token not set to either GITHUB_TOKEN or GH_TOKEN. Exiting..." && exit 1; fi
+        if [ -z "$GITHUB_TOKEN" ] && [ -z "$GH_TOKEN" ]; then echo "Github Token not set to either GITHUB_TOKEN or GH_TOKEN. Exiting..." && exit 1; fi
     - install_binaries: npm i --no-save semantic-release@^22
     - publish: ./node_modules/.bin/semantic-release


### PR DESCRIPTION
## Context
Semantic release allows for configuring GitHub token secrets using either `GITHUB_TOKEN` or `GH_TOKEN`.

## Objective
Adds support for pipelines to be configured with GITHUB_TOKEN

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
